### PR TITLE
Add custom checkstyle xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,11 @@ in this sample. These and others are explained in the next section.
 
 ``` groovy
 estilo {
-  source 'google' // starting point for checkstyle checks (other option: 'sun')
+  // starting point for checkstyle checks (other options: google, sun)
+  source 'empty' 
+  
+  // you can specify a path to a custom starting point checkstyle.xml instead of choosing from a template above. 
+  customSource ''
 
   ignoreWarnings true // ignore checkstyle warning and let the build continue
   

--- a/src/main/groovy/net/anshulverma/gradle/estilo/EstiloExtension.groovy
+++ b/src/main/groovy/net/anshulverma/gradle/estilo/EstiloExtension.groovy
@@ -41,6 +41,10 @@ class EstiloExtension {
     baseChecks = CheckType.valueOf(type.toUpperCase())
   }
 
+  def customSource(String configPath){
+    baseChecks = CheckType.setCustom(configPath)
+  }
+
   def checks(Closure closure) {
     checkCollection = evaluate('checks', new PropertyCollection(), closure)
   }

--- a/src/main/groovy/net/anshulverma/gradle/estilo/EstiloPlugin.groovy
+++ b/src/main/groovy/net/anshulverma/gradle/estilo/EstiloPlugin.groovy
@@ -29,7 +29,7 @@ import org.gradle.api.Project
 class EstiloPlugin implements Plugin<Project> {
 
   @Override
-  void apply(def Project project) {
+  void apply(Project project) {
     if (project.plugins.hasPlugin('java')) {
       def buildDir = "${project.buildDir}/estilo"
 

--- a/src/main/groovy/net/anshulverma/gradle/estilo/checkstyle/checks/CheckType.groovy
+++ b/src/main/groovy/net/anshulverma/gradle/estilo/checkstyle/checks/CheckType.groovy
@@ -18,14 +18,24 @@ package net.anshulverma.gradle.estilo.checkstyle.checks
 /**
  * @author Anshul Verma (anshul.verma86@gmail.com)
  */
-public enum CheckType {
+public class CheckType {
 
-  GOOGLE('google_checks.xml'),
-  SUN('sun_checks.xml')
+  public static GOOGLE = new CheckType('google_checks.xml')
+  public static SUN = new CheckType('sun_checks.xml')
+  public static EMPTY = new CheckType('empty_checks.xml')
+  public static CUSTOM = new CheckType("config/checkstyle.xml")
 
   final String filename
 
   private CheckType(def filename) {
     this.filename = filename
+  }
+
+  static setCustom(String filename){
+    CUSTOM = new CheckType(filename)
+  }
+
+  static CheckType valueOf(String name){
+    CheckType.class.getField(name).get(null) as CheckType
   }
 }

--- a/src/main/groovy/net/anshulverma/gradle/estilo/checkstyle/checks/ConfigFileLoader.groovy
+++ b/src/main/groovy/net/anshulverma/gradle/estilo/checkstyle/checks/ConfigFileLoader.groovy
@@ -21,6 +21,8 @@ import net.anshulverma.gradle.estilo.checkstyle.config.CheckstyleConfig
 import net.anshulverma.gradle.estilo.checkstyle.config.ConfigMarshaller
 import org.apache.commons.io.FileUtils
 
+import java.nio.file.Paths
+
 /**
  * @author Anshul Verma (anshul.verma86@gmail.com)
  */
@@ -31,12 +33,16 @@ class ConfigFileLoader {
   CheckType checkType
 
   CheckstyleConfig load() {
-    loadResource("/${checkType.filename}")
+    if(checkType == CheckType.CUSTOM){
+      loadUrl(new File(checkType.filename).toURI().toURL())
+    }else{
+      loadUrl(this.getClass().getResource("/${checkType.filename}"))
+    }
   }
 
-  private CheckstyleConfig loadResource(String resource) {
-    File tmpFile = File.createTempFile('checkstyle', checkType.filename)
-    FileUtils.copyURLToFile(this.getClass().getResource(resource), tmpFile)
+  private CheckstyleConfig loadUrl(URL url){
+    File tmpFile = File.createTempFile('checkstyle', Paths.get(checkType.filename).getFileName().toString())
+    FileUtils.copyURLToFile(url, tmpFile)
     ConfigMarshaller.INSTANCE.unmarshal(tmpFile)
   }
 }

--- a/src/main/resources/empty_checks.xml
+++ b/src/main/resources/empty_checks.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0"?>
+<!DOCTYPE module PUBLIC
+        "-//Puppy Crawl//DTD Check Configuration 1.2//EN"
+        "http://www.puppycrawl.com/dtds/configuration_1_2.dtd">
+<module name="Checker">
+
+</module>

--- a/src/test/groovy/net/anshulverma/gradle/estilo/EstiloExtensionTest.groovy
+++ b/src/test/groovy/net/anshulverma/gradle/estilo/EstiloExtensionTest.groovy
@@ -43,6 +43,29 @@ class EstiloExtensionTest extends AbstractSpecification {
       checkType        | name
       CheckType.GOOGLE | 'google'
       CheckType.SUN    | 'sun'
+      CheckType.EMPTY  | 'empty'
+      CheckType.CUSTOM | 'custom'
+  }
+
+  def 'Allow custom baseChecks'(){
+    given:
+      def extention = new EstiloExtension()
+      def closure = {
+        customSource checkstylePath
+      }
+      closure.delegate = extention
+
+    when:
+      closure()
+
+    then:
+      extention.baseChecks.filename == checkstylePath
+
+    where:
+      checktype                                 | checkstylePath
+      CheckType.CUSTOM                          | 'config/checkstyle.xml'
+      CheckType.setCustom('/path/to/somewhere') | '/path/to/somewhere'
+
   }
 
   def 'Allow adding RegexpHeader check'() {

--- a/src/test/groovy/net/anshulverma/gradle/estilo/checkstyle/checks/FileLoaderTest.groovy
+++ b/src/test/groovy/net/anshulverma/gradle/estilo/checkstyle/checks/FileLoaderTest.groovy
@@ -21,6 +21,8 @@ import net.anshulverma.gradle.estilo.test.AbstractSpecification
 import org.apache.commons.io.IOUtils
 import org.codehaus.plexus.util.FileUtils
 import spock.lang.Unroll
+
+import javax.xml.bind.DatatypeConverter
 import java.security.DigestInputStream
 import java.security.MessageDigest
 
@@ -38,7 +40,7 @@ class FileLoaderTest extends AbstractSpecification {
       settings.baseChecks = checkType
 
     when:
-      EstiloTask estiloTask = project.getTasksByName('estilo', true)[0]
+      EstiloTask estiloTask = project.getTasksByName('estilo', true)[0] as EstiloTask
       estiloTask.execute(settings)
 
     then:
@@ -50,6 +52,9 @@ class FileLoaderTest extends AbstractSpecification {
       checkType        | hash
       CheckType.GOOGLE | [44, -55, 53, -59, -34, -78, 95, -46, -92, 29, 109, -104, 126, -12, 120, -16]
       CheckType.SUN    | [123, -62, -28, 57, 21, -38, -118, -78, -54, -54, -44, 67, -21, 63, -66, -79]
+      CheckType.EMPTY  | hex2byte("3e9f1a5f8e8d821e443ead6b7daeeed6")
+
+    CheckType.setCustom("src/main/resources/empty_checks.xml") | hex2byte("3e9f1a5f8e8d821e443ead6b7daeeed6")
   }
 
   def fileHash(File file) {
@@ -57,5 +62,9 @@ class FileLoaderTest extends AbstractSpecification {
     DigestInputStream inputStream = new DigestInputStream(new FileInputStream(file), messageDigest)
     IOUtils.toByteArray(inputStream)
     messageDigest.digest()
+  }
+
+  def hex2byte(String hex){
+    DatatypeConverter.parseHexBinary(hex)
   }
 }


### PR DESCRIPTION
Two additional features in this PR: 

- Allowing the `source` to be an empty set of checks (well, the default ones in estilo), instead of using a template from google or sun. 
- Allowing a custom starting point to be defined. Ultimately I will need to figure out how to get the default settings from creeping in when using this feature. 

Also, I'm new to Groovy, so anything I can learn on how to do something better or if you have a different idea on how these features should be implemented, I am very open and interested to hear your thoughts. 